### PR TITLE
Implement config, templates and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Proyecto de ejemplo para generar informes de forma local utilizando un stack lib
 
 - `frontend/` – Aplicación de escritorio creada con Tauri + React + TailwindCSS + ShadCN UI.
 - `backend/` – API local en Python usando FastAPI con LangChain y Ollama.
-- `resources/` – Archivos estáticos y recursos (pendiente de uso).
-- `config/` – Archivos de configuración de la aplicación.
+- `resources/` – Plantillas para exportación (`template.docx`, `template.css`).
+- `config/` – Parámetros globales en `config.yaml`.
 
 ## Ejecución
 
@@ -52,6 +52,9 @@ python backend/main.py
 
 La API quedará disponible en `http://127.0.0.1:8000`.
 
+La configuración global se encuentra en `config/config.yaml` y permite definir
+la carpeta de exportación y plantillas.
+
 ### Frontend (Tauri)
 
 1. Instalar dependencias de Node:
@@ -68,6 +71,23 @@ npm run dev
 ```
 
 Tauri abrirá una ventana con el formulario para generar informes.
+
+### Pruebas
+
+Ejecuta las pruebas unitarias con:
+
+```bash
+pytest
+```
+
+### Empaquetado
+
+Para generar un ejecutable del backend se proporciona `backend/build.sh` que usa
+PyInstaller:
+
+```bash
+sh backend/build.sh
+```
 
 ## Flujo básico
 

--- a/backend/build.sh
+++ b/backend/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+pyinstaller --onefile --add-data ../config/config.yaml:config --add-data ../resources:resources backend/main.py

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,6 @@ uvicorn
 langchain
 ollama
 chromadb
-apache-tika
 pydantic
 python-multipart
 aiofiles

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,5 @@
+export_dir: exports
+default_author: "Anonimo"
+language: "es"
+docx_template: "../resources/template.docx"
+pdf_css: "../resources/template.css"

--- a/resources/template.css
+++ b/resources/template.css
@@ -1,0 +1,1 @@
+/* PDF template */

--- a/resources/template.docx
+++ b/resources/template.docx
@@ -1,0 +1,1 @@
+DOCX template placeholder

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+import os
+import sys
+sys.path.insert(0, os.path.abspath("."))
+from fastapi.testclient import TestClient
+import backend.main as bm
+
+
+def setup_module(module):
+    bm.HIST_PATH = Path("tests/tmp_hist.json")
+    if bm.HIST_PATH.exists():
+        bm.HIST_PATH.unlink()
+    bm.EXPORT_DIR = Path("tests/exports")
+    bm.EXPORT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+client = TestClient(bm.app)
+
+
+def test_generar(monkeypatch):
+    monkeypatch.setattr(bm, "generar_contenido", lambda t, ty: "contenido")
+    resp = client.post("/generar", json={"tema": "x", "tipo": "y"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "contenido" in data
+
+
+def test_exportar(monkeypatch, tmp_path):
+    file = tmp_path / "tmp.docx"
+    monkeypatch.setattr(bm, "exportar_a_archivo", lambda c, f: str(file))
+    resp = client.post("/exportar", json={"contenido": "c", "formato": "docx"})
+    assert resp.status_code == 200
+
+
+def test_buscar(monkeypatch):
+    item = {
+        "id": "1",
+        "tema": "t",
+        "tipo": "r",
+        "contenido": "algo",
+        "timestamp": "2024",
+    }
+    bm.guardar_historial([item])
+
+    class DummyCol:
+        def query(self, query_embeddings, n_results, include):
+            return {
+                "ids": [["1"]],
+                "metadatas": [[{"tema": "t", "tipo": "r", "timestamp": "2024"}]],
+            }
+
+    monkeypatch.setattr(bm, "collection", DummyCol())
+    monkeypatch.setattr(bm.embedder, "encode", lambda x: [0.0])
+
+    resp = client.post("/buscar", json={"query": "algo"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["id"] == "1"


### PR DESCRIPTION
## Summary
- drop apache-tika from requirements
- add YAML configuration and export templates
- load config in backend and enhance export
- return snippet in search results
- improve React frontend with loading/error states
- add PyInstaller build script
- create pytest suite for API
- document config, tests and build steps

## Testing
- `pip install fastapi` *(failed: ModuleNotFoundError until installed)*
- `pip install httpx` *(installed dependency)*
- `pytest -q` *(failed: ModuleNotFoundError: No module named 'langchain')*

------
https://chatgpt.com/codex/tasks/task_e_6853f4924cd48326ad3e95ad2f1ecad9