### PR TITLE
Fix import path for Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ source venv/bin/activate  # En Windows: venv\Scripts\activate
 
 ```bash
 pip install -r backend/requirements.txt
+pip install -U langchain-community sentence-transformers
 ```
 
 4. Instalar Pandoc (si no est\u00e1 en el sistema). En Debian/Ubuntu puedes ejecutar:

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 from datetime import datetime
 from pathlib import Path
 from pydantic import BaseModel
-from langchain.llms import Ollama
+from langchain_community.llms import Ollama
 import chromadb
 from sentence_transformers import SentenceTransformer
 import yaml

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn
 langchain
+langchain-community
 ollama
 chromadb
 pydantic


### PR DESCRIPTION
## Summary
- update deprecated LangChain import in `backend/main.py`
- include `langchain-community` in requirements
- document installing new dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6853faf7b2c48326b88ad3731f6ce520