### PR TITLE
Handle missing Ollama dependency

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -119,6 +119,8 @@ def sync_chroma() -> None:
 
 def generar_contenido(tema: str, tipo: str) -> str:
     """Genera un informe usando LangChain + Ollama."""
+    if llm is None:
+        raise HTTPException(status_code=500, detail="Modelo Ollama no disponible")
     prompt = (
         f"Redacta un informe profesional tipo \"{tipo}\" sobre el tema: \"{tema}\". "
         "Incluye introducci\u00f3n, desarrollo argumental y conclusiones."

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,6 +26,13 @@ def test_generar(monkeypatch):
     assert "contenido" in data
 
 
+def test_generar_sin_llm(monkeypatch):
+    monkeypatch.setattr(bm, "llm", None)
+    resp = client.post("/generar", json={"tema": "x", "tipo": "y"})
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Modelo Ollama no disponible"
+
+
 def test_exportar(monkeypatch, tmp_path):
     file = tmp_path / "tmp.docx"
     monkeypatch.setattr(bm, "exportar_a_archivo", lambda c, f: str(file))


### PR DESCRIPTION
## Summary
- return a clear error when Ollama isn't installed
- test generating reports without Ollama available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68540d70a46483269e3945f60d07d132