### PR TITLE
Implement loading spinner and Spanish output

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -131,7 +131,7 @@ def generar_contenido(tema: str, tipo: str) -> str:
     if llm is None:
         raise HTTPException(status_code=500, detail="Modelo Ollama no disponible")
     prompt = (
-        f"Redacta un informe profesional tipo \"{tipo}\" sobre el tema: \"{tema}\". "
+        f"Redacta un informe profesional en espa\u00f1ol tipo \"{tipo}\" sobre el tema: \"{tema}\". "
         "Incluye introducci\u00f3n, desarrollo argumental y conclusiones."
     )
     try:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -152,7 +152,31 @@ export default function App() {
       </div>
 
       {error && <div className="text-red-600 mb-2">{error}</div>}
-      {loading && <div className="mb-2">Cargando...</div>}
+      {loading && (
+        <div className="mb-2 flex items-center gap-2">
+          <svg
+            className="animate-spin h-5 w-5 text-blue-600"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            ></circle>
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+            ></path>
+          </svg>
+          <span>Cargando...</span>
+        </div>
+      )}
 
       {activeTab === "generar" && (
         <>


### PR DESCRIPTION
## Summary
- ensure generated content is in Spanish
- show loading spinner during async operations

## Testing
- `pip install -r backend/requirements.txt`
- `pip install -U langchain-community sentence-transformers`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68542a3661408326b83c30256d05ff82