### PR TITLE
Implement conversational assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ El backend se expone en: `http://127.0.0.1:8000`.
 
 CORS habilitado para: `http://127.0.0.1:1420` y `http://localhost:1420`.
 
+### Endpoints relevantes
+
+- `POST /asistente/{id}` – Conversación paso a paso. Envía `{ "mensaje": "texto" }` para
+  avanzar y obtener el contexto requerido antes de generar el informe.
+- `POST /generar` – Genera el informe con los datos recopilados.
+
 ---
 
 ### Frontend (Tauri)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,8 +19,32 @@ def setup_module(module):
 client = TestClient(bm.app)
 
 
+def test_asistente_flujo():
+    cid = "test_conv"
+    resp = client.post(f"/asistente/{cid}", json={"mensaje": "hola"})
+    assert resp.status_code == 200
+    assert "Para qué" in resp.json()["reply"]
+
+    resp = client.post(f"/asistente/{cid}", json={"mensaje": "Trabajo"})
+    assert "tema" in resp.json()["reply"].lower()
+
+    resp = client.post(f"/asistente/{cid}", json={"mensaje": "IA"})
+    assert "estilo" in resp.json()["reply"].lower()
+
+    resp = client.post(f"/asistente/{cid}", json={"mensaje": "tecnico"})
+    assert "páginas" in resp.json()["reply"].lower() or "paginas" in resp.json()["reply"].lower()
+
+    resp = client.post(f"/asistente/{cid}", json={"mensaje": "5"})
+    assert "fuentes" in resp.json()["reply"].lower()
+
+    resp = client.post(f"/asistente/{cid}", json={"mensaje": "ninguna"})
+    data = resp.json()
+    assert data["reply"] == "Contexto completado"
+    assert data["contexto"]["paginas"] == 5
+
+
 def test_generar(monkeypatch):
-    monkeypatch.setattr(bm, "generar_contenido", lambda t, ty: "contenido")
+    monkeypatch.setattr(bm, "generar_contenido", lambda *a, **k: "contenido")
     resp = client.post("/generar", json={"tema": "x", "tipo": "y"})
     assert resp.status_code == 200
     data = resp.json()


### PR DESCRIPTION
## Summary
- add a conversational endpoint `/asistente/{id}`
- support extra context fields in `/generar`
- update tests for conversation flow
- document new endpoints in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854342b88ec83269032abf25d11fcb9