### PR TITLE
Implement multi-step frontend UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "@tauri-apps/plugin-opener": "^2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-markdown": "^8.0.7"
+    "react-markdown": "^8.0.7",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,279 +1,101 @@
-import { useEffect, useState } from "react";
-import ReactMarkdown from "react-markdown";
-
-interface GenerarResponse {
-  id: string;
-  contenido: string;
-}
-
-interface HistItem {
-  id: string;
-  tema: string;
-  tipo: string;
-  timestamp: string;
-}
+import { useState } from "react";
+import Chat, { Contexto } from "./components/Chat";
+import Generate from "./components/Generate";
+import EditPanel from "./components/EditPanel";
+import ExportView from "./components/ExportView";
+import Historial from "./components/Historial";
 
 export default function App() {
-  const [tema, setTema] = useState("");
-  const [tipo, setTipo] = useState("");
-  const [resultado, setResultado] = useState("");
-  const [vistaPrevia, setVistaPrevia] = useState(false);
-  const [formato, setFormato] = useState("docx");
-  const [historial, setHistorial] = useState<HistItem[]>([]);
-  const [busqueda, setBusqueda] = useState("");
-  const [activeTab, setActiveTab] = useState<"generar" | "historial">("generar");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
-
-  useEffect(() => {
-    cargarHistorial();
-  }, []);
-
-  async function cargarHistorial() {
-    const resp = await fetch("http://127.0.0.1:8000/historial");
-    if (resp.ok) {
-      const data = (await resp.json()) as HistItem[];
-      setHistorial(data);
-    }
-  }
-
-  async function generar() {
-    setLoading(true);
-    setError("");
-    const resp = await fetch("http://127.0.0.1:8000/generar", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ tema, tipo }),
-    });
-    if (!resp.ok) {
-      setError("Error al generar informe");
-      setLoading(false);
-      return;
-    }
-    const data = (await resp.json()) as GenerarResponse;
-    setResultado(data.contenido);
-    setVistaPrevia(false);
-    setLoading(false);
-    cargarHistorial();
-  }
-
-  async function exportar() {
-    setLoading(true);
-    const resp = await fetch("http://127.0.0.1:8000/exportar", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ contenido: resultado, formato }),
-    });
-    setLoading(false);
-    if (!resp.ok) {
-      setError("Error al exportar");
-      return;
-    }
-    const blob = await resp.blob();
-    const url = window.URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `informe_generado.${formato}`;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    window.URL.revokeObjectURL(url);
-  }
-
-  async function cargarInforme(id: string) {
-    const resp = await fetch(`http://127.0.0.1:8000/historial/${id}`);
-    if (resp.ok) {
-      const data = (await resp.json()) as HistItem & { contenido: string };
-      setTema(data.tema);
-      setTipo(data.tipo);
-      setResultado(data.contenido);
-      setVistaPrevia(false);
-      setActiveTab("generar");
-    }
-  }
-
-  async function eliminarInforme(id: string) {
-    await fetch(`http://127.0.0.1:8000/historial/${id}`, { method: "DELETE" });
-    setHistorial((prev) => prev.filter((it) => it.id !== id));
-  }
-
-  async function exportarHistorial(id: string, fmt: string) {
-    const resp = await fetch(
-      `http://127.0.0.1:8000/historial/${id}?exportar=${fmt}`
-    );
-    if (!resp.ok) return;
-    const blob = await resp.blob();
-    const url = window.URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `informe_generado.${fmt}`;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    window.URL.revokeObjectURL(url);
-  }
-
-  async function buscarHistorial(e: React.FormEvent) {
-    e.preventDefault();
-    if (!busqueda) {
-      cargarHistorial();
-      return;
-    }
-    const resp = await fetch("http://127.0.0.1:8000/buscar", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ query: busqueda }),
-    });
-    if (resp.ok) {
-      const data = (await resp.json()) as HistItem[];
-      setHistorial(data);
-    }
-  }
+  const [view, setView] = useState<"chat" | "generate" | "edit" | "export" | "history">("chat");
+  const [contexto, setContexto] = useState<Contexto | null>(null);
+  const [tipo, setTipo] = useState("Informe");
+  const [texto, setTexto] = useState("");
 
   return (
-    <main className="min-h-screen flex flex-col items-center justify-start p-8 gap-4">
-      <h1 className="text-2xl font-bold">Generador de Informes</h1>
-      <div className="flex gap-4 mb-4">
-        <button
-          className={`p-2 rounded ${activeTab === "generar" ? "bg-blue-600 text-white" : "bg-gray-200"}`}
-          onClick={() => setActiveTab("generar")}
-        >
-          Generar
-        </button>
-        <button
-          className={`p-2 rounded ${activeTab === "historial" ? "bg-blue-600 text-white" : "bg-gray-200"}`}
-          onClick={() => {
-            setActiveTab("historial");
-            cargarHistorial();
-          }}
-        >
-          Historial
-        </button>
-      </div>
+    <main className="min-h-screen flex flex-col items-center p-4 gap-4">
+      <h1 className="text-2xl font-bold mb-2">IA Work Generator</h1>
 
-      {error && <div className="text-red-600 mb-2">{error}</div>}
-      {loading && (
-        <div className="mb-2 flex items-center gap-2">
-          <svg
-            className="animate-spin h-5 w-5 text-blue-600"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            ></circle>
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-            ></path>
-          </svg>
-          <span>Cargando...</span>
-        </div>
-      )}
-
-      {activeTab === "generar" && (
+      {view === "chat" && (
         <>
-          <form
-            className="flex flex-col gap-4 w-full max-w-md"
-            onSubmit={(e) => {
-              e.preventDefault();
-              generar();
+          <Chat
+            onCompleted={(ctx) => {
+              setContexto(ctx);
+              setView("generate");
             }}
-          >
-            <input
-              className="border rounded p-2"
-              value={tema}
-              onChange={(e) => setTema(e.currentTarget.value)}
-              placeholder="Tema del informe"
-            />
+          />
+          <div className="mt-2 flex flex-col gap-2 w-full max-w-xs">
+            <label className="text-sm">Tipo de informe</label>
             <input
               className="border rounded p-2"
               value={tipo}
               onChange={(e) => setTipo(e.currentTarget.value)}
-              placeholder="Tipo de informe"
             />
-            <button className="bg-blue-600 text-white rounded p-2" type="submit">
-              Generar
-            </button>
-          </form>
-
-          {resultado && (
-            <>
-              <button
-                className="text-sm text-blue-600 mb-2"
-                onClick={() => setVistaPrevia(!vistaPrevia)}
-              >
-                {vistaPrevia ? "Ver como texto plano" : "Ver con formato"}
-              </button>
-              {vistaPrevia ? (
-                <div className="prose max-w-md bg-white p-4 border rounded">
-                  <ReactMarkdown>{resultado}</ReactMarkdown>
-                </div>
-              ) : (
-                <pre className="mt-0 bg-gray-100 p-4 rounded w-full max-w-md whitespace-pre-wrap">
-                  {resultado}
-                </pre>
-              )}
-              <div className="mt-2 flex items-center gap-2">
-                <select
-                  className="border rounded p-2"
-                  value={formato}
-                  onChange={(e) => setFormato(e.currentTarget.value)}
-                >
-                  <option value="docx">DOCX</option>
-                  <option value="pdf">PDF</option>
-                </select>
-                <button
-                  className="bg-green-600 text-white rounded p-2"
-                  onClick={exportar}
-                >
-                  Exportar informe
-                </button>
-              </div>
-            </>
-          )}
+          </div>
         </>
       )}
 
-      {activeTab === "historial" && (
-        <div className="w-full max-w-md">
-          <form className="mb-2 flex" onSubmit={buscarHistorial}>
-            <input
-              className="border rounded p-2 flex-1"
-              placeholder="Buscar..."
-              value={busqueda}
-              onChange={(e) => setBusqueda(e.currentTarget.value)}
-            />
-            <button className="ml-2 p-2 bg-blue-600 text-white rounded" type="submit">
-              Buscar
-            </button>
-          </form>
-          <ul>
-            {historial.map((item) => (
-              <li key={item.id} className="border-b p-2 flex justify-between items-start">
-                <div className="flex-1 cursor-pointer" onClick={() => cargarInforme(item.id)}>
-                  <div className="font-semibold">{item.tema}</div>
-                  <div className="text-sm text-gray-500">
-                    {item.tipo} - {new Date(item.timestamp).toLocaleString()}
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  <button className="text-blue-600 text-sm" onClick={() => exportarHistorial(item.id, "docx")}>DOCX</button>
-                  <button className="text-blue-600 text-sm" onClick={() => exportarHistorial(item.id, "pdf")}>PDF</button>
-                  <button className="text-red-600 text-sm" onClick={() => eliminarInforme(item.id)}>Eliminar</button>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </div>
+      {view === "generate" && contexto && (
+        <Generate
+          ctx={{ ...contexto, tipo }}
+          onDone={(t) => {
+            setTexto(t);
+            setView("edit");
+          }}
+        />
       )}
+
+      {view === "edit" && (
+        <EditPanel
+          initial={texto}
+          onSave={(t) => setTexto(t)}
+          onRegenerate={() => setView("generate")}
+          onBack={() => setView("chat")}
+          onExport={() => setView("export")}
+        />
+      )}
+
+      {view === "export" && (
+        <ExportView
+          contenido={texto}
+          onFinish={() => setView("edit")}
+        />
+      )}
+
+      {view === "history" && (
+        <Historial
+          onSelect={(id) => {
+            fetch(`http://127.0.0.1:8000/historial/${id}`)
+              .then((r) => r.json())
+              .then((data) => {
+                setTexto(data.contenido);
+                setContexto({
+                  proposito: data.proposito,
+                  tema: data.tema,
+                  estilo: data.estilo,
+                  paginas: data.paginas,
+                  extras: data.extras,
+                });
+                setTipo(data.tipo);
+                setView("edit");
+              });
+          }}
+        />
+      )}
+
+      <div className="mt-4 flex gap-2">
+        <button
+          className="px-3 py-1 bg-blue-600 text-white rounded"
+          onClick={() => setView("chat")}
+        >
+          Chat
+        </button>
+        <button
+          className="px-3 py-1 bg-gray-200 rounded"
+          onClick={() => setView("history")}
+        >
+          Historial
+        </button>
+      </div>
     </main>
   );
 }

--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState, useRef } from "react";
+import { v4 as uuidv4 } from "uuid";
+
+export interface Contexto {
+  proposito?: string;
+  tema?: string;
+  estilo?: string;
+  paginas?: number;
+  extras?: string;
+}
+
+interface ChatProps {
+  onCompleted: (ctx: Contexto) => void;
+}
+
+interface Mensaje {
+  from: "bot" | "user";
+  text: string;
+}
+
+export default function Chat({ onCompleted }: ChatProps) {
+  const [messages, setMessages] = useState<Mensaje[]>([]);
+  const [input, setInput] = useState("");
+  const [convId] = useState(() => uuidv4());
+  const ctxRef = useRef<Contexto>({});
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    async function init() {
+      const resp = await fetch(`http://127.0.0.1:8000/asistente/${convId}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mensaje: "hola" }),
+      });
+      if (resp.ok) {
+        const data = await resp.json();
+        setMessages([{ from: "bot", text: data.reply }]);
+      }
+    }
+    init();
+  }, [convId]);
+
+  async function send() {
+    if (!input) return;
+    const txt = input;
+    setMessages((prev) => [...prev, { from: "user", text: txt }]);
+    setInput("");
+    const resp = await fetch(`http://127.0.0.1:8000/asistente/${convId}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mensaje: txt }),
+    });
+    if (resp.ok) {
+      const data = await resp.json();
+      if (data.contexto) {
+        ctxRef.current = data.contexto as Contexto;
+      }
+      setMessages((prev) => [...prev, { from: "bot", text: data.reply }]);
+      if (data.contexto) {
+        onCompleted(ctxRef.current);
+      }
+    }
+    inputRef.current?.focus();
+  }
+
+  return (
+    <div className="w-full max-w-xl flex flex-col gap-2">
+      <div className="flex-1 border rounded p-2 h-80 overflow-y-auto bg-white">
+        {messages.map((m, idx) => (
+          <div key={idx} className={`mb-1 ${m.from === "bot" ? "text-blue-700" : "text-gray-800"}`}>{m.text}</div>
+        ))}
+      </div>
+      <div className="flex gap-2 mt-2">
+        <input
+          ref={inputRef}
+          className="flex-1 border rounded p-2"
+          placeholder="Escribe tu respuesta..."
+          value={input}
+          onChange={(e) => setInput(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              send();
+            }
+          }}
+        />
+        <button className="bg-blue-600 text-white rounded px-4" onClick={send}>
+          Enviar
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/EditPanel.tsx
+++ b/frontend/src/components/EditPanel.tsx
@@ -1,0 +1,69 @@
+import ReactMarkdown from "react-markdown";
+import { useState } from "react";
+
+interface Props {
+  initial: string;
+  onSave: (text: string) => void;
+  onRegenerate: () => void;
+  onBack: () => void;
+  onExport: () => void;
+}
+
+export default function EditPanel({
+  initial,
+  onSave,
+  onRegenerate,
+  onBack,
+  onExport,
+}: Props) {
+  const [text, setText] = useState(initial);
+  const [preview, setPreview] = useState(false);
+
+  return (
+    <div className="w-full max-w-2xl flex flex-col gap-2">
+      <div className="flex gap-2 mb-2">
+        <button
+          className="px-3 py-1 rounded bg-blue-600 text-white"
+          onClick={() => setPreview(!preview)}
+        >
+          {preview ? "Editar" : "Vista"}
+        </button>
+        <button
+          className="px-3 py-1 rounded bg-green-600 text-white"
+          onClick={() => onSave(text)}
+        >
+          Guardar cambios
+        </button>
+        <button
+          className="px-3 py-1 rounded bg-yellow-600 text-white"
+          onClick={onRegenerate}
+        >
+          Generar de nuevo
+        </button>
+        <button
+          className="px-3 py-1 rounded bg-gray-500 text-white"
+          onClick={onBack}
+        >
+          Volver al chat
+        </button>
+        <button
+          className="px-3 py-1 rounded bg-purple-600 text-white ml-auto"
+          onClick={onExport}
+        >
+          Exportar
+        </button>
+      </div>
+      {preview ? (
+        <div className="prose border rounded p-2 bg-white max-h-96 overflow-y-auto">
+          <ReactMarkdown>{text}</ReactMarkdown>
+        </div>
+      ) : (
+        <textarea
+          className="border rounded p-2 h-96 w-full"
+          value={text}
+          onChange={(e) => setText(e.currentTarget.value)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ExportView.tsx
+++ b/frontend/src/components/ExportView.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+
+interface Props {
+  contenido: string;
+  onFinish: () => void;
+}
+
+export default function ExportView({ contenido, onFinish }: Props) {
+  const [format, setFormat] = useState("docx");
+  const [msg, setMsg] = useState("");
+
+  async function exportar() {
+    const resp = await fetch("http://127.0.0.1:8000/exportar", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ contenido, formato: format }),
+    });
+    if (!resp.ok) return setMsg("Error al exportar");
+    const blob = await resp.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `informe.${format}`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    window.URL.revokeObjectURL(url);
+    setMsg("Exportación completada");
+  }
+
+  return (
+    <div className="w-full max-w-sm flex flex-col gap-4">
+      <div>
+        <label className="mr-2">Formato:</label>
+        <select
+          className="border rounded p-2"
+          value={format}
+          onChange={(e) => setFormat(e.currentTarget.value)}
+        >
+          <option value="docx">DOCX</option>
+          <option value="pdf">PDF</option>
+        </select>
+      </div>
+      <button className="bg-green-600 text-white rounded p-2" onClick={exportar}>
+        Exportar informe
+      </button>
+      {msg && <div className="text-sm text-blue-700">{msg}</div>}
+      <button className="text-sm underline" onClick={onFinish}>
+        Volver
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/Generate.tsx
+++ b/frontend/src/components/Generate.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState, useRef } from "react";
+import ReactMarkdown from "react-markdown";
+import { Contexto } from "./Chat";
+
+interface Props {
+  ctx: Contexto & { tipo: string };
+  onDone: (texto: string) => void;
+}
+
+export default function Generate({ ctx, onDone }: Props) {
+  const [text, setText] = useState("");
+  const [display, setDisplay] = useState("");
+  const [running, setRunning] = useState(true);
+  const timer = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    async function run() {
+      const resp = await fetch("http://127.0.0.1:8000/generar", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(ctx),
+      });
+      if (resp.ok) {
+        const data = await resp.json();
+        setText(data.contenido);
+      }
+    }
+    run();
+    return () => {
+      if (timer.current) clearInterval(timer.current);
+    };
+  }, [ctx]);
+
+  useEffect(() => {
+    if (!text) return;
+    let i = 0;
+    timer.current = setInterval(() => {
+      i += 1;
+      setDisplay(text.slice(0, i));
+      if (i >= text.length) {
+        if (timer.current) clearInterval(timer.current);
+        setRunning(false);
+        onDone(text);
+      }
+    }, 30);
+  }, [text, onDone]);
+
+  return (
+    <div className="w-full max-w-2xl">
+      <div className="mb-2 p-2 border rounded bg-gray-50">
+        <div className="text-sm text-gray-600">Tema: {ctx.tema}</div>
+        <div className="text-sm text-gray-600">Estilo: {ctx.estilo}</div>
+        <div className="text-sm text-gray-600">Páginas: {ctx.paginas}</div>
+      </div>
+      <div className="prose max-h-96 overflow-y-auto border rounded p-2 bg-white">
+        <ReactMarkdown>{display}</ReactMarkdown>
+      </div>
+      {running && (
+        <button
+          className="mt-2 bg-red-600 text-white px-4 py-1 rounded"
+          onClick={() => {
+            if (timer.current) clearInterval(timer.current);
+            setRunning(false);
+          }}
+        >
+          Detener generación
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Historial.tsx
+++ b/frontend/src/components/Historial.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+
+interface HistItem {
+  id: string;
+  tema: string;
+  tipo: string;
+  timestamp: string;
+}
+
+interface Props {
+  onSelect: (id: string) => void;
+}
+
+export default function Historial({ onSelect }: Props) {
+  const [items, setItems] = useState<HistItem[]>([]);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    cargar();
+  }, []);
+
+  async function cargar() {
+    const resp = await fetch("http://127.0.0.1:8000/historial");
+    if (resp.ok) setItems(await resp.json());
+  }
+
+  async function buscar(e: React.FormEvent) {
+    e.preventDefault();
+    if (!query) return cargar();
+    const resp = await fetch("http://127.0.0.1:8000/buscar", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query }),
+    });
+    if (resp.ok) setItems(await resp.json());
+  }
+
+  async function eliminar(id: string) {
+    await fetch(`http://127.0.0.1:8000/historial/${id}`, { method: "DELETE" });
+    setItems((prev) => prev.filter((i) => i.id !== id));
+  }
+
+  return (
+    <div className="w-full max-w-md">
+      <form className="flex mb-2" onSubmit={buscar}>
+        <input
+          className="flex-1 border rounded p-2"
+          placeholder="Buscar..."
+          value={query}
+          onChange={(e) => setQuery(e.currentTarget.value)}
+        />
+        <button className="ml-2 bg-blue-600 text-white px-4 rounded" type="submit">
+          Buscar
+        </button>
+      </form>
+      <ul>
+        {items.map((it) => (
+          <li key={it.id} className="border-b p-2 flex justify-between">
+            <div className="flex-1 cursor-pointer" onClick={() => onSelect(it.id)}>
+              <div className="font-semibold">{it.tema}</div>
+              <div className="text-sm text-gray-500">
+                {it.tipo} - {new Date(it.timestamp).toLocaleString()}
+              </div>
+            </div>
+            <button className="text-red-600 text-sm" onClick={() => eliminar(it.id)}>
+              Eliminar
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement chat wizard for assistant questions
- add generation view with typewriter effect and stop option
- create markdown editor and export panel
- add history search component
- wire screens together with simple navigation

## Testing
- `pytest -q` *(fails: ImportError: module 'langchain_core.callbacks.manager' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543aa10cf483268c412f5168656e6d