### PR TITLE
Implement chat outline confirmation

### DIFF
--- a/frontend/src/components/Chat.tsx
+++ b/frontend/src/components/Chat.tsx
@@ -24,6 +24,7 @@ export default function Chat({ onCompleted }: ChatProps) {
   const [convId] = useState(() => uuidv4());
   const ctxRef = useRef<Contexto>({});
   const inputRef = useRef<HTMLInputElement>(null);
+  const [waitingConfirm, setWaitingConfirm] = useState(false);
 
   useEffect(() => {
     async function init() {
@@ -56,7 +57,11 @@ export default function Chat({ onCompleted }: ChatProps) {
         ctxRef.current = data.contexto as Contexto;
       }
       setMessages((prev) => [...prev, { from: "bot", text: data.reply }]);
+      if (data.estructura) {
+        setWaitingConfirm(true);
+      }
       if (data.contexto) {
+        setWaitingConfirm(false);
         onCompleted(ctxRef.current);
       }
     }
@@ -74,7 +79,7 @@ export default function Chat({ onCompleted }: ChatProps) {
         <input
           ref={inputRef}
           className="flex-1 border rounded p-2"
-          placeholder="Escribe tu respuesta..."
+          placeholder={waitingConfirm ? "¿Aceptas la estructura?" : "Escribe tu respuesta..."}
           value={input}
           onChange={(e) => setInput(e.currentTarget.value)}
           onKeyDown={(e) => {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,7 +19,8 @@ def setup_module(module):
 client = TestClient(bm.app)
 
 
-def test_asistente_flujo():
+def test_asistente_flujo(monkeypatch):
+    monkeypatch.setattr(bm, "generar_estructura", lambda *a, **k: "estructura")
     cid = "test_conv"
     resp = client.post(f"/asistente/{cid}", json={"mensaje": "hola"})
     assert resp.status_code == 200
@@ -38,6 +39,9 @@ def test_asistente_flujo():
     assert "fuentes" in resp.json()["reply"].lower()
 
     resp = client.post(f"/asistente/{cid}", json={"mensaje": "ninguna"})
+    assert "estructura" in resp.json()["reply"].lower()
+
+    resp = client.post(f"/asistente/{cid}", json={"mensaje": "sí"})
     data = resp.json()
     assert data["reply"] == "Contexto completado"
     assert data["contexto"]["paginas"] == 5


### PR DESCRIPTION
## Summary
- add outline generation step before report creation
- update chat frontend to handle structure confirmation
- adjust tests for new flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543e61a4208326a477d06d774f2cfe