### PR TITLE
Improve context assistant with dynamic questions

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,11 @@ client = TestClient(bm.app)
 
 def test_asistente_flujo(monkeypatch):
     monkeypatch.setattr(bm, "generar_estructura", lambda *a, **k: "estructura")
+    monkeypatch.setattr(
+        bm,
+        "generar_pregunta",
+        lambda paso, est: bm._PREGUNTAS_PREDETERMINADAS.get(paso, ""),
+    )
     cid = "test_conv"
     resp = client.post(f"/asistente/{cid}", json={"mensaje": "hola"})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- let the assistant generate context questions dynamically when Ollama is available
- adjust API tests to mock dynamic question generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68544f8bb4dc83268639b538c04c6363