### PR TITLE
Add test for conversar endpoint

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -108,3 +108,14 @@ def test_buscar(monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert data[0]["id"] == "1"
+
+
+def test_conversar_iniciar():
+    """Ensure conversar endpoint triggers generation flag."""
+    resp = client.post(
+        "/conversar",
+        json={"mensaje": "Quiero generar un informe sobre IA"},
+    )
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["iniciar_generacion"] is True


### PR DESCRIPTION
## Summary
- test the new `/conversar` endpoint to ensure it triggers generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68548585a80c8326b82208fe606bfc47