### PR TITLE
Fix bot reply handling in chat

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -33,8 +33,13 @@ export default function ChatInterface() {
       });
       if (!resp.ok) throw new Error("request failed");
       const data = await resp.json();
-      const reply: string =
-        data.respuesta ?? data.reply ?? data.result ?? "Sin respuesta.";
+      console.log(data);
+      let reply: string | undefined =
+        data.respuesta ?? data.message ?? data.text ?? data.result;
+      if (!reply) {
+        console.warn("Respuesta vacía o malformada", data);
+        reply = "Sin respuesta generada.";
+      }
       setMessages((p) => [...p, { role: "bot", text: reply, id: Date.now() }]);
     } catch (err) {
       setMessages((p) => [

--- a/frontend/src/components/MainInterface.tsx
+++ b/frontend/src/components/MainInterface.tsx
@@ -42,7 +42,14 @@ export default function MainInterface() {
       });
       if (!resp.ok) throw new Error("Request failed");
       const data = await resp.json();
-      setMessages((p) => [...p, { role: "bot", text: data.respuesta }]);
+      console.log(data);
+      let reply: string | undefined =
+        data.respuesta ?? data.message ?? data.text ?? data.result;
+      if (!reply) {
+        console.warn("Respuesta vacía o malformada", data);
+        reply = "Sin respuesta generada.";
+      }
+      setMessages((p) => [...p, { role: "bot", text: reply }]);
       if (data.iniciar_generacion) {
         setShowGen(true);
         setGenerating(true);


### PR DESCRIPTION
## Summary
- robust error handling when reading bot responses
- warn if chatbot returns an empty result
- add debugging output for backend payloads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685493d3f97c83268940cebfc09866fb