### PR TITLE
Update fetch response handling

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -33,9 +33,9 @@ export default function ChatInterface() {
       });
       if (!resp.ok) throw new Error("request failed");
       const data = await resp.json();
-      console.log(data);
+      console.log("DEBUG response:", data);
       let reply: string | undefined =
-        data.respuesta ?? data.message ?? data.text ?? data.result;
+        data.respuesta ?? data.text ?? data.resultado ?? data.message ?? data.result;
       if (!reply) {
         console.warn("Respuesta vacía o malformada", data);
         reply = "Sin respuesta generada.";

--- a/frontend/src/components/MainInterface.tsx
+++ b/frontend/src/components/MainInterface.tsx
@@ -42,9 +42,9 @@ export default function MainInterface() {
       });
       if (!resp.ok) throw new Error("Request failed");
       const data = await resp.json();
-      console.log(data);
+      console.log("DEBUG response:", data);
       let reply: string | undefined =
-        data.respuesta ?? data.message ?? data.text ?? data.result;
+        data.respuesta ?? data.text ?? data.resultado ?? data.message ?? data.result;
       if (!reply) {
         console.warn("Respuesta vacía o malformada", data);
         reply = "Sin respuesta generada.";


### PR DESCRIPTION
## Summary
- log responses from `/conversar` with a DEBUG prefix
- support alternate response fields when parsing the answer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854967be02483269f177f392c2eaa48