### PR TITLE
Fix frontend parsing of backend response

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -35,7 +35,12 @@ export default function ChatInterface() {
       const data = await resp.json();
       console.log("DEBUG response:", data);
       let reply: string | undefined =
-        data.respuesta ?? data.text ?? data.resultado ?? data.message ?? data.result;
+        data.respuesta ??
+        data.respuesta_generada ??
+        data.text ??
+        data.resultado ??
+        data.message ??
+        data.result;
       if (!reply) {
         console.warn("Respuesta vacía o malformada", data);
         reply = "Sin respuesta generada.";

--- a/frontend/src/components/MainInterface.tsx
+++ b/frontend/src/components/MainInterface.tsx
@@ -44,7 +44,12 @@ export default function MainInterface() {
       const data = await resp.json();
       console.log("DEBUG response:", data);
       let reply: string | undefined =
-        data.respuesta ?? data.text ?? data.resultado ?? data.message ?? data.result;
+        data.respuesta ??
+        data.respuesta_generada ??
+        data.text ??
+        data.resultado ??
+        data.message ??
+        data.result;
       if (!reply) {
         console.warn("Respuesta vacía o malformada", data);
         reply = "Sin respuesta generada.";


### PR DESCRIPTION
## Summary
- handle `respuesta_generada` field when reading backend replies

## Testing
- `npm test --silent` *(fails: no tests defined)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68549a5bc2e48326969724d3894b669b