### PR TITLE
Fix chat message parsing

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -33,14 +33,14 @@ export default function ChatInterface() {
       });
       if (!resp.ok) throw new Error("request failed");
       const data = await resp.json();
-      console.log("DEBUG response:", data);
-      let reply: string | undefined =
-        data.respuesta ??
-        data.respuesta_generada ??
-        data.text ??
-        data.resultado ??
-        data.message ??
-        data.result;
+      console.log("Respuesta del backend:", data);
+      let reply =
+        data?.respuesta ??
+        data?.respuesta_generada ??
+        data?.text ??
+        data?.resultado ??
+        data?.message ??
+        data?.result;
       if (!reply) {
         console.warn("Respuesta vacía o malformada", data);
         reply = "Sin respuesta generada.";

--- a/frontend/src/components/MainInterface.tsx
+++ b/frontend/src/components/MainInterface.tsx
@@ -42,14 +42,14 @@ export default function MainInterface() {
       });
       if (!resp.ok) throw new Error("Request failed");
       const data = await resp.json();
-      console.log("DEBUG response:", data);
-      let reply: string | undefined =
-        data.respuesta ??
-        data.respuesta_generada ??
-        data.text ??
-        data.resultado ??
-        data.message ??
-        data.result;
+      console.log("Respuesta del backend:", data);
+      let reply =
+        data?.respuesta ??
+        data?.respuesta_generada ??
+        data?.text ??
+        data?.resultado ??
+        data?.message ??
+        data?.result;
       if (!reply) {
         console.warn("Respuesta vacía o malformada", data);
         reply = "Sin respuesta generada.";


### PR DESCRIPTION
## Summary
- log backend responses and check for missing data
- gracefully handle empty replies in chat components

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68549bea723c83269bc46c675ed37fc5