### PR TITLE
Fix reply parsing

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -34,13 +34,7 @@ export default function ChatInterface() {
       if (!resp.ok) throw new Error("request failed");
       const data = await resp.json();
       console.log("Respuesta del backend:", data);
-      let reply =
-        data?.respuesta ??
-        data?.respuesta_generada ??
-        data?.text ??
-        data?.resultado ??
-        data?.message ??
-        data?.result;
+      let reply = data?.respuesta;
       if (!reply) {
         console.warn("Respuesta vacía o malformada", data);
         reply = "Sin respuesta generada.";

--- a/frontend/src/components/MainInterface.tsx
+++ b/frontend/src/components/MainInterface.tsx
@@ -43,13 +43,7 @@ export default function MainInterface() {
       if (!resp.ok) throw new Error("Request failed");
       const data = await resp.json();
       console.log("Respuesta del backend:", data);
-      let reply =
-        data?.respuesta ??
-        data?.respuesta_generada ??
-        data?.text ??
-        data?.resultado ??
-        data?.message ??
-        data?.result;
+      let reply = data?.respuesta;
       if (!reply) {
         console.warn("Respuesta vacía o malformada", data);
         reply = "Sin respuesta generada.";


### PR DESCRIPTION
## Summary
- parse `respuesta` field from conversation API
- clean up conditional parsing logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npx vitest run` *(fails: requires download)*

------
https://chatgpt.com/codex/tasks/task_e_68549e5bb9e88326b06d357f4d2d0fb2