### PR TITLE
Improve frontend response parsing

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -32,16 +32,23 @@ export default function ChatInterface() {
         body: JSON.stringify({ mensaje: text }),
       });
       if (!resp.ok) throw new Error("request failed");
-      const data = await resp.json();
-      console.log("Respuesta del backend:", data);
-      let reply =
-        data?.respuesta ||
-        data?.reply ||
-        data?.content ||
-        data?.message ||
-        "";
+      const raw = await resp.text();
+      let data: any = null;
+      let reply = "";
+      try {
+        data = JSON.parse(raw);
+        reply =
+          data?.respuesta ||
+          data?.reply ||
+          data?.content ||
+          data?.message ||
+          "";
+      } catch (e) {
+        reply = raw.trim();
+      }
+      console.log("Respuesta del backend:", data || raw);
       if (!reply) {
-        console.warn("Respuesta vacía o malformada", data);
+        console.warn("Respuesta vacía o malformada", data || raw);
         reply = "Sin respuesta generada.";
       }
       setMessages((p) => [...p, { role: "bot", text: reply, id: Date.now() }]);

--- a/frontend/src/components/MainInterface.tsx
+++ b/frontend/src/components/MainInterface.tsx
@@ -41,16 +41,23 @@ export default function MainInterface() {
         body: JSON.stringify({ mensaje: text }),
       });
       if (!resp.ok) throw new Error("Request failed");
-      const data = await resp.json();
-      console.log("Respuesta del backend:", data);
-      let reply =
-        data?.respuesta ||
-        data?.reply ||
-        data?.content ||
-        data?.message ||
-        "";
+      const raw = await resp.text();
+      let data: any = null;
+      let reply = "";
+      try {
+        data = JSON.parse(raw);
+        reply =
+          data?.respuesta ||
+          data?.reply ||
+          data?.content ||
+          data?.message ||
+          "";
+      } catch (e) {
+        reply = raw.trim();
+      }
+      console.log("Respuesta del backend:", data || raw);
       if (!reply) {
-        console.warn("Respuesta vacía o malformada", data);
+        console.warn("Respuesta vacía o malformada", data || raw);
         reply = "Sin respuesta generada.";
       }
       setMessages((p) => [...p, { role: "bot", text: reply }]);


### PR DESCRIPTION
## Summary
- fix ChatInterface to parse raw response text before JSON
- apply same change to MainInterface

## Testing
- `pip install fastapi uvicorn`
- `pip install httpx pyyaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a45d6e4c832697cc6fd0bd85b276