### PR TITLE
Minor fix: placeholder reply when no LLM

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -560,8 +560,9 @@ async def conversar(req: ConversacionRequest):
         print("Respuesta generada:", texto)
         return {"respuesta": texto}
 
-    respuesta = ""
-    if llm:
+    if llm is None:
+        respuesta = "[LLM no disponible]"
+    else:
         try:
             respuesta = _invoke_llm(prompt)
         except Exception:


### PR DESCRIPTION
## Summary
- handle missing language model in `conversar`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a5b97cac8326b530aec143671886