### PR TITLE
Add Conversar frontend agent

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,10 +22,13 @@
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/react-hooks": "^0.2.1",
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.1",
     "typescript": "~5.6.2",
-    "vite": "^6.0.3"
+    "vite": "^6.0.3",
+    "vitest": "^1.0.0"
   }
 }

--- a/frontend/src/agents/Conversar/store.ts
+++ b/frontend/src/agents/Conversar/store.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+import { Mensaje, EstadoConversacion } from './types';
+
+interface ConversarStore extends EstadoConversacion {
+  setMensajeActual: (msg: string) => void;
+  addMensaje: (msg: Mensaje) => void;
+  setRespuesta: (resp: string) => void;
+  clear: () => void;
+}
+
+export const useConversarStore = create<ConversarStore>((set) => ({
+  respuesta: '',
+  mensajeActual: '',
+  historial: [],
+  setMensajeActual: (mensajeActual) => set({ mensajeActual }),
+  addMensaje: (msg) => set((state) => ({ historial: [...state.historial, msg] })),
+  setRespuesta: (respuesta) => set({ respuesta }),
+  clear: () => set({ respuesta: '', mensajeActual: '', historial: [] }),
+}));

--- a/frontend/src/agents/Conversar/types.ts
+++ b/frontend/src/agents/Conversar/types.ts
@@ -1,0 +1,10 @@
+export interface Mensaje {
+  role: 'user' | 'bot';
+  text: string;
+}
+
+export interface EstadoConversacion {
+  respuesta: string;
+  mensajeActual: string;
+  historial: Mensaje[];
+}

--- a/frontend/src/agents/Conversar/useConversar.ts
+++ b/frontend/src/agents/Conversar/useConversar.ts
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { request } from '../../request';
+import { useConversarStore } from './store';
+
+export function useConversar() {
+  const { respuesta, mensajeActual, historial, setMensajeActual, addMensaje, setRespuesta } = useConversarStore();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function enviarMensaje() {
+    if (!mensajeActual.trim() || loading) return;
+    const texto = mensajeActual;
+    setMensajeActual('');
+    addMensaje({ role: 'user', text: texto });
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await request<{ respuesta?: string; reply?: string }>('/conversar', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mensaje: texto }),
+      });
+      const reply = data.respuesta || data.reply || '';
+      setRespuesta(reply);
+      addMensaje({ role: 'bot', text: reply });
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return {
+    respuesta,
+    mensajeActual,
+    historial,
+    setMensajeActual,
+    enviarMensaje,
+    estado: { loading, error },
+  };
+}

--- a/frontend/src/request.ts
+++ b/frontend/src/request.ts
@@ -1,0 +1,21 @@
+export interface RequestOptions extends RequestInit {
+  retries?: number;
+}
+
+export async function request<T = any>(url: string, options: RequestOptions = {}): Promise<T> {
+  const { retries = 0, ...init } = options;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const resp = await fetch(url, init);
+      if (!resp.ok) throw new Error(`Request failed with ${resp.status}`);
+      const text = await resp.text();
+      try {
+        return JSON.parse(text) as T;
+      } catch {
+        return text as unknown as T;
+      }
+    } catch (err) {
+      if (attempt >= retries) throw err;
+    }
+  }
+}

--- a/frontend/tests/agents/Conversar/useConversar.test.ts
+++ b/frontend/tests/agents/Conversar/useConversar.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useConversar } from '../../../src/agents/Conversar/useConversar';
+import { useConversarStore } from '../../../src/agents/Conversar/store';
+
+vi.mock('../../../src/request', () => ({
+  request: vi.fn(() => Promise.resolve({ respuesta: 'ok' })),
+}));
+
+describe('useConversar', () => {
+  it('updates state after sending message', async () => {
+    const { result } = renderHook(() => useConversar());
+    act(() => {
+      result.current.setMensajeActual('hola');
+    });
+    await act(async () => {
+      await result.current.enviarMensaje();
+    });
+    expect(result.current.respuesta).toBe('ok');
+    expect(useConversarStore.getState().historial).toHaveLength(2);
+    expect(useConversarStore.getState().historial[1].text).toBe('ok');
+  });
+});


### PR DESCRIPTION
## Summary
- add Zustand store/types for Conversar agent
- implement useConversar hook using request wrapper
- provide minimal request wrapper
- set up vitest deps and a simple test

## Testing
- `npx vitest run --dir tests/agents/Conversar` *(fails: missing dependencies)*
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6854a73728108326af36243219e7c76c