### PR TITLE
Improve LLM error reporting

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -119,3 +119,12 @@ def test_conversar_iniciar():
     assert resp.status_code == 200
     payload = resp.json()
     assert payload["iniciar_generacion"] is True
+    assert "error" in payload
+
+
+def test_conversar_sin_llm(monkeypatch):
+    monkeypatch.setattr(bm, "llm", None)
+    resp = client.post("/conversar", json={"mensaje": "hola"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["error"] == "LLM no disponible"


### PR DESCRIPTION
## Summary
- raise an explicit HTTP 503 error from `_invoke_llm` when the model is unavailable
- surface that error in `/conversar` responses and keep context fields
- extend API tests to cover new error behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a89b5c108326a7b4182266785630