### PR TITLE
Handle backend error messages in chat

### DIFF
--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -35,7 +35,10 @@ export default function ChatInterface() {
           body: JSON.stringify({ mensaje: text }),
         }
       );
-      const reply = data.respuesta || data.reply || "";
+      let reply = data.respuesta || data.reply || "";
+      if (!reply && (data as any).error) {
+        reply = `Error: ${(data as any).error}`;
+      }
       if (!reply) {
         console.warn("Respuesta vacía o malformada", data);
       }

--- a/frontend/src/components/MainInterface.tsx
+++ b/frontend/src/components/MainInterface.tsx
@@ -56,6 +56,9 @@ export default function MainInterface() {
         reply = raw.trim();
       }
       console.log("Respuesta del backend:", data || raw);
+      if (!reply && data?.error) {
+        reply = `Error: ${data.error}`;
+      }
       if (!reply) {
         console.warn("Respuesta vacía o malformada", data || raw);
         reply = "Sin respuesta generada.";


### PR DESCRIPTION
## Summary
- display backend error messages in `ChatInterface`
- show backend errors in `MainInterface`

## Testing
- `pytest -q`
- `npx vitest run --silent`

------
https://chatgpt.com/codex/tasks/task_e_6854b1d88a588326a1d41ca3dd4e02e9