### PR TITLE
Fix Windows notes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Antes de compilar, asegúrese de disponer de Ollama y Pandoc en el sistema anfit
 ollama pull mixtral          # recomendado
 ollama pull mistral          # alternativa para hardware limitado
 ollama serve &
+# en Windows usa `ollama serve` (o `start "" /B ollama serve`) en su propia consola
+# si aparece el mensaje "Only one usage of each socket address..." quiere decir
+# que otra instancia de `ollama` sigue activa. Mata el proceso anterior y vuelve a intentarlo.
 
 # Backend
 python -m venv venv


### PR DESCRIPTION
## Summary
- add Windows instructions for starting the Ollama server
- explain how to resolve the 'Only one usage...' error

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6854b909d0008326966fc80a7649eba8