### PR TITLE
Fix encoding and language detection

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,4 @@ aiofiles
 sentence-transformers
 httpx
 langchain_ollama
+langdetect


### PR DESCRIPTION
## Summary
- force UTF-8 JSON responses
- detect language of prompts to enforce consistent replies
- clean output and remove stray translations
- require `langdetect` in backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854cad34f2c83269478e1d63b86284c