### PR TITLE
Fix subprocess encoding for Windows

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -79,6 +79,7 @@ def _invoke_llm(prompt: str) -> str:
                     text=True,
                     capture_output=True,
                     check=True,
+                    encoding="utf-8",
                 )
                 return proc.stdout
             except Exception as exc:  # pragma: no cover - runtime connectivity issues


### PR DESCRIPTION
## Summary
- ensure `subprocess.run` uses UTF-8 when invoking `ollama`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6854cfc57c58832696aa716957e03fbb