### PR TITLE
Add document upload endpoint and context support

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,6 @@ sentence-transformers
 httpx
 langchain_ollama
 langdetect
+pdfplumber
+python-docx
+PyMuPDF

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -130,3 +130,20 @@ def test_conversar_sin_llm(monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert data["error"] == "LLM no disponible"
+
+
+def test_documento_txt(tmp_path):
+    file = tmp_path / "prueba.txt"
+    file.write_text("hola", encoding="utf-8")
+    with file.open("rb") as fh:
+        resp = client.post("/documento", files={"file": ("prueba.txt", fh, "text/plain")})
+    assert resp.status_code == 200
+    assert resp.json()["contenido"] == "hola"
+
+
+def test_documento_invalido(tmp_path):
+    file = tmp_path / "bad.bin"
+    file.write_bytes(b"123")
+    with file.open("rb") as fh:
+        resp = client.post("/documento", files={"file": ("bad.bin", fh, "application/octet-stream")})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- allow uploading `.pdf`, `.docx` and `.txt` files through new `POST /documento`
- extract text using pdfplumber/PyMuPDF, python-docx or a simple text read
- make extracted text usable as context when generating reports
- record uploads in temporary folder
- update dependencies and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854d2fff70c8326a470f877aa8aae6c