### PR TITLE
Add dynamic language switching

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,31 @@
+import { useEffect, useState } from "react";
 import ChatInterface from "./components/ChatInterface";
+import Settings from "./components/Settings";
+import { request } from "./request";
 
 export default function App() {
+  const [view, setView] = useState<"chat" | "settings">("chat");
+
+  useEffect(() => {
+    const lang = localStorage.getItem("idioma");
+    if (lang) {
+      request("/config/idioma", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ idioma: lang }),
+      }).catch(() => {});
+    }
+  }, []);
+
   return (
-    <div className="h-screen">
-      <ChatInterface />
+    <div className="h-screen flex flex-col">
+      <header className="p-2 bg-gray-800 text-white flex gap-4">
+        <button onClick={() => setView("chat")}>Chat</button>
+        <button onClick={() => setView("settings")}>Settings</button>
+      </header>
+      <div className="flex-1">
+        {view === "chat" ? <ChatInterface /> : <Settings />}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import { Select } from "./ui/select";
+import { request } from "../request";
+
+export default function Settings() {
+  const [lang, setLang] = useState("es");
+  const [msg, setMsg] = useState("");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("idioma");
+    if (stored) setLang(stored);
+  }, []);
+
+  async function change(value: string) {
+    setLang(value);
+    localStorage.setItem("idioma", value);
+    try {
+      await request("/config/idioma", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ idioma: value }),
+      });
+      setMsg(value === "es" ? "Idioma cambiado a Español" : "Language switched to English");
+    } catch {
+      setMsg("Error");
+    }
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div>
+        <label className="block mb-1 font-medium">Idioma</label>
+        <Select value={lang} onChange={(e) => change(e.currentTarget.value)}>
+          <option value="es">Español</option>
+          <option value="en">English</option>
+        </Select>
+      </div>
+      {msg && <div className="text-sm text-green-600">{msg}</div>}
+    </div>
+  );
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -147,3 +147,19 @@ def test_documento_invalido(tmp_path):
     with file.open("rb") as fh:
         resp = client.post("/documento", files={"file": ("bad.bin", fh, "application/octet-stream")})
     assert resp.status_code == 400
+
+
+def test_cambiar_idioma():
+    resp = client.post("/config/idioma", json={"idioma": "en"})
+    assert resp.status_code == 200
+    assert resp.json()["idioma"] == "en"
+
+
+def test_conversar_cambia_idioma(monkeypatch):
+    monkeypatch.setattr(bm, "_invoke_llm", lambda p: p)
+    resp = client.post("/conversar", json={"mensaje": "cambia el idioma a ingles"})
+    assert resp.status_code == 200
+    assert "Ingl" in resp.json()["respuesta"] or "English" in resp.json()["respuesta"]
+    resp2 = client.post("/conversar", json={"mensaje": "hola"})
+    assert resp2.status_code == 200
+    assert resp2.json()["respuesta"].startswith("Answer in English:")


### PR DESCRIPTION
## Summary
- enable per-session language tracking in backend
- add endpoint `/config/idioma`
- detect language switch commands in chat
- update assistant functions to respect language
- add Settings view in frontend with language selector
- expose settings via menu
- test language change functionality

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6854d722bac48326923082e716eff544