### PR TITLE
Add automatic Word generation from chat

### DIFF
--- a/backend/document_generator.py
+++ b/backend/document_generator.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+from fastapi import HTTPException
+try:
+    from docx import Document
+except Exception:  # pragma: no cover - optional dependency
+    Document = None
+
+
+def crear_docx(secciones: dict, tmp_dir: Path) -> str:
+    """Construye un archivo DOCX básico a partir de secciones."""
+    if not Document:
+        raise HTTPException(status_code=500, detail="Soporte DOCX no disponible")
+
+    doc = Document()
+    titulo = secciones.get("titulo", "Informe")
+    doc.add_heading(titulo, level=1)
+
+    intro = secciones.get("introduccion")
+    if intro:
+        doc.add_heading("Introducción", level=2)
+        doc.add_paragraph(intro)
+
+    desarrollo = secciones.get("desarrollo")
+    if desarrollo:
+        doc.add_heading("Desarrollo", level=2)
+        for bloque in desarrollo.split("\n\n"):
+            doc.add_paragraph(bloque)
+
+    conclusion = secciones.get("conclusion")
+    if conclusion:
+        doc.add_heading("Conclusión", level=2)
+        doc.add_paragraph(conclusion)
+
+    path = tmp_dir / f"{uuid4()}.docx"
+    doc.save(path)
+    return str(path)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -171,6 +171,26 @@ def test_generar_docx(monkeypatch):
     )
 
 
+def test_conversar_generar_word(monkeypatch):
+    def fake_llm(prompt, session_id="default"):
+        if "título" in prompt.lower():
+            return "Titulo"
+        if "introducción" in prompt.lower():
+            return "Intro"
+        if "desarrolla" in prompt.lower():
+            return "Desarrollo"
+        if "concluye" in prompt.lower():
+            return "Conclusión"
+        return "ok"
+
+    monkeypatch.setattr(bm, "invoke_llm", fake_llm)
+    resp = client.post("/conversar", json={"mensaje": "Genera un Word sobre IA"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
+
+
 def test_cambiar_idioma():
     resp = client.post("/config/idioma", json={"idioma": "en"})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- centralize DOCX creation in new `document_generator` module
- add helper `generar_docx_tema` to produce Word files
- detect Word generation requests inside `/conversar`
- return generated DOCX directly from chat
- test new flow with pytest

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6854e41c2d2c8326b79ee9a9de673e1e